### PR TITLE
Migrate to es-toolkit

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,8 +13,8 @@
     "apcach": "^0.6.4",
     "clsx": "^2.1.1",
     "culori": "^4.0.1",
+    "es-toolkit": "^1.34.1",
     "fast-equals": "^5.2.2",
-    "lodash-es": "^4.17.21",
     "nanoid": "^5.1.5",
     "react": "catalog:",
     "react-dom": "catalog:",
@@ -23,7 +23,6 @@
   },
   "devDependencies": {
     "@types/culori": "^2.1.1",
-    "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.13.10",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:"

--- a/packages/core/src/stores/colors.ts
+++ b/packages/core/src/stores/colors.ts
@@ -23,8 +23,8 @@ import {
 import { objectEntries } from "@core/utils/object/objectEntries";
 import { workerChannel } from "@core/worker/workerChannel";
 import { batch, type WritableSignal } from "@spred/core";
-import debounce from "lodash-es/debounce";
-import pick from "lodash-es/pick";
+import { pick } from "es-toolkit";
+import { debounce } from "es-toolkit/compat";
 
 import { FALLBACK_CELL_COLOR, FALLBACK_HUE_DATA, FALLBACK_LEVEL_DATA } from "./constants";
 import {

--- a/packages/core/src/utils/dnd/handleSnappedHorizontalDrag.ts
+++ b/packages/core/src/utils/dnd/handleSnappedHorizontalDrag.ts
@@ -1,5 +1,5 @@
 import { isRtl } from "@core/utils/dom/isRtlDirection";
-import throttle from "lodash-es/throttle";
+import { throttle } from "es-toolkit";
 
 type SnappedHorizontalDragOptions = {
   element: HTMLElement;

--- a/packages/core/src/utils/spred/createScrollStateSignal.ts
+++ b/packages/core/src/utils/spred/createScrollStateSignal.ts
@@ -1,6 +1,6 @@
 import { effect, type Signal, signal } from "@spred/core";
+import { debounce } from "es-toolkit/compat";
 import { shallowEqual } from "fast-equals";
-import debounce from "lodash-es/debounce";
 
 import { getScrollState, type ScrollState, type ScrollType } from "../dom/getScrollState";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,12 +115,12 @@ importers:
       culori:
         specifier: ^4.0.1
         version: 4.0.1
+      es-toolkit:
+        specifier: ^1.34.1
+        version: 1.34.1
       fast-equals:
         specifier: ^5.2.2
         version: 5.2.2
-      lodash-es:
-        specifier: ^4.17.21
-        version: 4.17.21
       nanoid:
         specifier: ^5.1.5
         version: 5.1.5
@@ -140,9 +140,6 @@ importers:
       '@types/culori':
         specifier: ^2.1.1
         version: 2.1.1
-      '@types/lodash-es':
-        specifier: ^4.17.12
-        version: 4.17.12
       '@types/node':
         specifier: ^22.13.10
         version: 22.13.10
@@ -835,12 +832,6 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/lodash-es@4.17.12':
-    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
-
-  '@types/lodash@4.17.16':
-    resolution: {integrity: sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==}
-
   '@types/node@22.13.10':
     resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
 
@@ -1371,6 +1362,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.34.1:
+    resolution: {integrity: sha512-OA6cd94fJV9bm8dWhIySkWq4xV+rAQnBZUr2dnpXam0QJ8c+hurLbKA8/QooL9Mx4WCAxvIDsiEkid5KPQ5xgQ==}
 
   esbuild@0.25.1:
     resolution: {integrity: sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==}
@@ -2098,9 +2092,6 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
-
-  lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -3465,12 +3456,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/lodash-es@4.17.12':
-    dependencies:
-      '@types/lodash': 4.17.16
-
-  '@types/lodash@4.17.16': {}
-
   '@types/node@22.13.10':
     dependencies:
       undici-types: 6.20.0
@@ -4157,6 +4142,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.34.1: {}
 
   esbuild@0.25.1:
     optionalDependencies:
@@ -4940,8 +4927,6 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  lodash-es@4.17.21: {}
 
   lodash.merge@4.6.2: {}
 


### PR DESCRIPTION
`es-toolkit` is the modern alternative to lodash. It is smaller, more performant and works better with tree-shaking.