### PR TITLE
Always render menu dropdown part

### DIFF
--- a/packages/core/src/components/Menu/Menu.tsx
+++ b/packages/core/src/components/Menu/Menu.tsx
@@ -27,15 +27,13 @@ export function Menu({ renderTrigger, children }: MenuProps) {
   return (
     <MenuContext.Provider value={{ api }}>
       {renderTrigger(api.getTriggerProps(), api.getIndicatorProps())}
-      {api.open && (
-        <Portal>
-          <div {...api.getPositionerProps()} className={styles.dropdown}>
-            <List as="div" {...api.getContentProps()}>
-              {children}
-            </List>
-          </div>
-        </Portal>
-      )}
+      <Portal>
+        <div {...api.getPositionerProps()} className={styles.dropdown}>
+          <List as="div" {...api.getContentProps()}>
+            {children}
+          </List>
+        </div>
+      </Portal>
     </MenuContext.Provider>
   );
 }


### PR DESCRIPTION
This pull request modifies the `Menu` component to simplify its rendering logic by removing the conditional check for `api.open`. The dropdown menu will now always render within the `Portal`, regardless of the `api.open` state.

Key change:

* [`packages/core/src/components/Menu/Menu.tsx`](diffhunk://#diff-d426f983edb7c751decdb922e89d8544b3178b8a2515a73ba003f472dc95cdadL30-L38): Removed the conditional `api.open` check, ensuring the dropdown menu is always rendered inside the `Portal`. This simplifies the component's structure and may improve consistency in how the dropdown is handled.…to be rendered even after click on the item