### PR TITLE
Fix wrong level header color

### DIFF
--- a/packages/core/src/components/BgMode/BgMode.tsx
+++ b/packages/core/src/components/BgMode/BgMode.tsx
@@ -5,17 +5,17 @@ import clsx from "clsx";
 import type { PolymorphicComponentPropsWithRef } from "@core/utils/react/polymorphic";
 
 import styles from "./BgMode.module.css";
-import type { BgColor, BgModeType } from "./types";
+import type { BgColorType, BgModeType } from "./types";
 
 export type BgModeProps<E extends ElementType> = PolymorphicComponentPropsWithRef<E> & {
   className?: string;
-  bgColor: BgColor | null;
+  bgColorType: BgColorType | null;
   bgMode: BgModeType;
 };
 
 export function BgMode<E extends ElementType>({
   as,
-  bgColor,
+  bgColorType,
   bgMode,
   ...restProps
 }: BgModeProps<E>) {
@@ -24,7 +24,7 @@ export function BgMode<E extends ElementType>({
   return (
     <Component
       {...restProps}
-      className={clsx(styles.bgMode, bgColor && styles[bgColor], restProps.className)}
+      className={clsx(styles.bgMode, bgColorType && styles[bgColorType], restProps.className)}
       data-bg-mode={bgMode}
     />
   );

--- a/packages/core/src/components/BgMode/types.ts
+++ b/packages/core/src/components/BgMode/types.ts
@@ -1,2 +1,2 @@
-export type BgColor = "left" | "right";
+export type BgColorType = "left" | "right";
 export type BgModeType = "light" | "dark";

--- a/packages/core/src/components/FloatingActions/FloatingActions.tsx
+++ b/packages/core/src/components/FloatingActions/FloatingActions.tsx
@@ -15,7 +15,7 @@ export function FloatingActions({ children }: FloatingActionsProps) {
   const bgMode = useSubscribe($bgColorModeRight);
 
   return (
-    <BgMode bgColor={null} bgMode={bgMode} className={styles.container}>
+    <BgMode bgColorType={null} bgMode={bgMode} className={styles.container}>
       {children}
     </BgMode>
   );

--- a/packages/core/src/components/Grid/Grid.tsx
+++ b/packages/core/src/components/Grid/Grid.tsx
@@ -75,7 +75,7 @@ type GridCellLightProps = {
 const GridCellRight = memo(function GridCellLight({ className }: GridCellLightProps) {
   const bgMode = useSubscribe($bgColorModeRight);
 
-  return <GridCell bgColor="right" bgMode={bgMode} className={className} />;
+  return <GridCell bgColorType="right" bgMode={bgMode} className={className} />;
 });
 
 export type GridBanner = {

--- a/packages/core/src/components/Grid/GridCellColor.tsx
+++ b/packages/core/src/components/Grid/GridCellColor.tsx
@@ -7,7 +7,7 @@ import { shallowEqual } from "fast-equals";
 import { Text } from "@core/components/Text/Text";
 import { OKLCH_WEB_URL } from "@core/constants";
 import { $hueIds, $levelIds, getColor$ } from "@core/stores/colors";
-import { useLevelBgColor, useLevelBgMode } from "@core/stores/hooks";
+import { useLevelBgColorType, useLevelBgMode } from "@core/stores/hooks";
 import type { ColorCellData, HueId, LevelId } from "@core/types";
 import { isLightColor } from "@core/utils/colors/isLightColor";
 
@@ -55,7 +55,7 @@ export const GridCellColor = memo(function GridCellColor({
 }: GridCellColorProps) {
   const color = useSubscribe(getColor$(levelId, hueId));
   const { isTl, isTr, isBl, isBr } = useColorCellModifiers(levelId, hueId);
-  const bgColor = useLevelBgColor(levelId);
+  const bgColorType = useLevelBgColorType(levelId);
   const bgStyle = useLevelBgMode(levelId);
   const bgMode = isLightColor(color.l) ? "dark" : "light";
 
@@ -67,7 +67,7 @@ export const GridCellColor = memo(function GridCellColor({
       className={clsx(styles.cell, className)}
       bgStyle={bgStyle}
       bgMode={bgMode === "light" ? "dark" : "light"}
-      bgColor={bgColor}
+      bgColorType={bgColorType}
       {...{ [DATA_ATTR_CELL_HUE_ID]: hueId, [DATA_ATTR_CELL_LEVEL_ID]: levelId }}
     >
       <div

--- a/packages/core/src/components/Grid/GridCellHueAdd.tsx
+++ b/packages/core/src/components/Grid/GridCellHueAdd.tsx
@@ -15,7 +15,7 @@ export const GridCellHueAdd = memo(function GridCellHueAdd() {
   const handleClick = useCallback(() => insertHue(), []);
 
   return (
-    <GridCell bgColor="left" bgMode={bgMode} className={styles.cell}>
+    <GridCell bgColorType="left" bgMode={bgMode} className={styles.cell}>
       <Button
         className={styles.button}
         kind="ghost"

--- a/packages/core/src/components/Grid/GridCellHueHeader.tsx
+++ b/packages/core/src/components/Grid/GridCellHueHeader.tsx
@@ -137,7 +137,7 @@ export const GridCellHueHeader = memo(function GridCellHueHeader({ hueId }: HueC
 
   return (
     <GridCell
-      bgColor="left"
+      bgColorType="left"
       bgMode={bgMode}
       className={styles.cell}
       {...{ [DATA_ATTR_CELL_HUE_ID]: hueId }}

--- a/packages/core/src/components/Grid/GridCellHueRemove.tsx
+++ b/packages/core/src/components/Grid/GridCellHueRemove.tsx
@@ -23,7 +23,7 @@ export const GridCellHueRemove = memo(function GridCellHueRemove({
 
   return (
     <GridCellRemoveAxis
-      bgColor="right"
+      bgColorType="right"
       bgMode={bgMode}
       {...{ [DATA_ATTR_CELL_HUE_ID]: hueId }}
       onClick={handleClick}

--- a/packages/core/src/components/Grid/GridCellLevelAdd.tsx
+++ b/packages/core/src/components/Grid/GridCellLevelAdd.tsx
@@ -18,7 +18,7 @@ export const GridCellLevelAdd = memo(function GridCellLevelAdd() {
   const handleClick = useCallback(() => insertLevel(), []);
 
   return (
-    <GridCell bgColor="right" bgMode={bgMode} className={styles.cell}>
+    <GridCell bgColorType="right" bgMode={bgMode} className={styles.cell}>
       <Button
         className={styles.addLevel}
         kind="bordered"

--- a/packages/core/src/components/Grid/GridCellLevelHeader.tsx
+++ b/packages/core/src/components/Grid/GridCellLevelHeader.tsx
@@ -3,7 +3,6 @@ import { type CSSProperties, memo, useCallback, useRef } from "react";
 import { useSignal, useSubscribe } from "@spred/react";
 import clsx from "clsx";
 
-import type { BgModeType } from "@core/components/BgMode/types";
 import { Button } from "@core/components/Button/Button";
 import { MPlus } from "@core/components/Icon/MPlus";
 import { withAutosize } from "@core/components/Input/enhancers/withAutosize";
@@ -26,11 +25,9 @@ import {
   updateLevelContrast,
   updateLevelName,
 } from "@core/stores/colors";
-import { useLevelBgColorType, useLevelBgMode } from "@core/stores/hooks";
+import { useLevelBgColorType, useLevelBgColorVariable, useLevelBgMode } from "@core/stores/hooks";
 import {
   $bgRightStart,
-  bgColorLeftStore,
-  bgColorRightStore,
   chromaModeStore,
   contrastModelStore,
   directionModeStore,
@@ -114,20 +111,15 @@ const NameInput = memo(function NameInput({ levelId }: LevelComponentProps) {
 });
 
 const LevelContrastInput = withValidation(withNumericIncrementControls(Input));
-const ContrastInput = memo(function ContrastInput({
-  levelId,
-  bgMode,
-}: LevelComponentProps<{ bgMode: BgModeType }>) {
+const ContrastInput = memo(function ContrastInput({ levelId }: LevelComponentProps) {
   const level = getLevel(levelId);
-  const bgColorRight = useSubscribe(bgColorRightStore.$raw);
-  const bgColorLeft = useSubscribe(bgColorLeftStore.$raw);
+  const bgColorVariable = useLevelBgColorVariable(levelId);
   const contrast = useSubscribe(level.contrast.$raw);
   const error = useSubscribe(level.contrast.$validationError);
   const contrastModel = useSubscribe(contrastModelStore.$lastValidValue);
 
   const tintColor = useSubscribe(level.$tintColor);
   const directionMode = useSubscribe(directionModeStore.$lastValidValue);
-  const currentBgColor = bgMode === "dark" ? bgColorLeft : bgColorRight;
 
   return (
     <LevelContrastInput
@@ -141,7 +133,7 @@ const ContrastInput = memo(function ContrastInput({
               "--input-border-color": formatOklch(tintColor, 0.2),
             }
           : {
-              "--input-color": currentBgColor,
+              "--input-color": bgColorVariable,
               "--input-border-color": tintColor.css,
               "--input-bg-color": tintColor.css,
             }

--- a/packages/core/src/components/Grid/GridCellLevelHeader.tsx
+++ b/packages/core/src/components/Grid/GridCellLevelHeader.tsx
@@ -26,7 +26,7 @@ import {
   updateLevelContrast,
   updateLevelName,
 } from "@core/stores/colors";
-import { useLevelBgColor, useLevelBgMode } from "@core/stores/hooks";
+import { useLevelBgColorType, useLevelBgMode } from "@core/stores/hooks";
 import {
   $bgRightStart,
   bgColorLeftStore,
@@ -214,19 +214,19 @@ const ChromaInput = memo(function ChromaInput({ levelId }: LevelComponentProps) 
 export const GridCellLevelHeader = memo(function GridCellLevelHeader({
   levelId,
 }: LevelComponentProps) {
-  const bgColor = useLevelBgColor(levelId);
+  const bgColorType = useLevelBgColorType(levelId);
   const bgMode = useLevelBgMode(levelId);
 
   return (
     <GridCell
-      bgColor={bgColor}
+      bgColorType={bgColorType}
       bgMode={bgMode}
       className={styles.cell}
       {...{ [DATA_ATTR_CELL_LEVEL_ID]: levelId }}
     >
       <InsertBeforeArea levelId={levelId} />
       <NameInput levelId={levelId} />
-      <ContrastInput levelId={levelId} bgMode={bgMode} />
+      <ContrastInput levelId={levelId} />
       <ChromaInput levelId={levelId} />
     </GridCell>
   );

--- a/packages/core/src/components/Grid/GridCellLevelRemove.tsx
+++ b/packages/core/src/components/Grid/GridCellLevelRemove.tsx
@@ -3,7 +3,7 @@ import { memo, useCallback } from "react";
 import { useSubscribe } from "@spred/react";
 
 import { getLevel, removeLevel } from "@core/stores/colors";
-import { useLevelBgColor, useLevelBgMode } from "@core/stores/hooks";
+import { useLevelBgColorType, useLevelBgMode } from "@core/stores/hooks";
 import type { LevelId } from "@core/types";
 
 import { DATA_ATTR_CELL_LEVEL_ID } from "./constants";
@@ -16,7 +16,7 @@ export type GridCellLevelRemoveProps = {
 export const GridCellLevelRemove = memo(function GridCellLevelRemove({
   levelId,
 }: GridCellLevelRemoveProps) {
-  const bgColor = useLevelBgColor(levelId);
+  const bgColorType = useLevelBgColorType(levelId);
   const bgMode = useLevelBgMode(levelId);
   const level = getLevel(levelId);
   const name = useSubscribe(level.name.$raw);
@@ -24,7 +24,7 @@ export const GridCellLevelRemove = memo(function GridCellLevelRemove({
 
   return (
     <GridCellRemoveAxis
-      bgColor={bgColor}
+      bgColorType={bgColorType}
       bgMode={bgMode}
       {...{ [DATA_ATTR_CELL_LEVEL_ID]: levelId }}
       onClick={handleClick}

--- a/packages/core/src/components/Grid/GridCellRemoveAxis.tsx
+++ b/packages/core/src/components/Grid/GridCellRemoveAxis.tsx
@@ -2,7 +2,7 @@ import { type HTMLAttributes, memo } from "react";
 
 import clsx from "clsx";
 
-import type { BgColor, BgModeType } from "@core/components/BgMode/types";
+import type { BgColorType, BgModeType } from "@core/components/BgMode/types";
 import { Button } from "@core/components/Button/Button";
 import { MBin } from "@core/components/Icon/MBin";
 
@@ -11,7 +11,7 @@ import { GridCell } from "./GridCell";
 import styles from "./GridCellRemoveAxis.module.css";
 
 export type GridCellRemoveAxisProps = HTMLAttributes<HTMLDivElement> & {
-  bgColor: BgColor;
+  bgColorType: BgColorType;
   bgMode: BgModeType;
   "aria-label": string;
   onClick: VoidFunction;

--- a/packages/core/src/components/Grid/GridLeftTopCell.tsx
+++ b/packages/core/src/components/Grid/GridLeftTopCell.tsx
@@ -45,7 +45,7 @@ export const GridLeftTopCell = memo(function GridLeftTopCell() {
   const isColorSpaceLocked = useSubscribe($isColorSpaceLocked);
 
   return (
-    <GridCell bgColor="left" bgMode={bgMode} className={styles.cell}>
+    <GridCell bgColorType="left" bgMode={bgMode} className={styles.cell}>
       <Text size="s" kind="secondary" className={styles.levelLabel}>
         {LABEL_LEVEL}
       </Text>

--- a/packages/core/src/components/Grid/GridRowBackground.tsx
+++ b/packages/core/src/components/Grid/GridRowBackground.tsx
@@ -18,7 +18,7 @@ import { $levelsCount } from "@core/stores/colors";
 import {
   $bgColorModeLeft,
   $bgColorModeRight,
-  $bgColorSingleBgColor,
+  $bgColorSingleBgColorType,
   $bgColorSingleBgMode,
   $bgColorSingleStore,
   $bgRightStart,
@@ -83,7 +83,7 @@ const RowHeaderCell = memo(function SpacerCell() {
   const bgMode = useSubscribe($bgColorModeLeft);
 
   return (
-    <GridCell bgColor="left" bgMode={bgMode} className={styles.rowHeader}>
+    <GridCell bgColorType="left" bgMode={bgMode} className={styles.rowHeader}>
       <Link size="s" href={EVIL_MARTIANS_URL} target="_blank">
         Harmonizer
         <br />
@@ -110,7 +110,7 @@ const BgSpanLeft = memo(function BgDarkSpan() {
   const { text: label, parts: bgLabelParts } = useBgLabel("dark");
 
   return (
-    <GridCell bgColor="left" bgMode={bgMode} className={clsx(styles.bgSpan, styles.left)}>
+    <GridCell bgColorType="left" bgMode={bgMode} className={clsx(styles.bgSpan, styles.left)}>
       {bgRightStart > 1 && <YoutubeLink />}
       <div className={styles.bgControlContainer}>
         <BgLabel bgLabelParts={bgLabelParts} />
@@ -130,7 +130,7 @@ const BgSpanLeft = memo(function BgDarkSpan() {
 
 const BgSpanSingle = memo(function BgSingleSpan() {
   const bgColorSingleStore = useSubscribe($bgColorSingleStore);
-  const singleBgColor = useSubscribe($bgColorSingleBgColor);
+  const singleBgColorType = useSubscribe($bgColorSingleBgColorType);
   const levelsCount = useSubscribe($levelsCount);
   const bgColor = useSubscribe(bgColorSingleStore.$raw);
   const bgMode = useSubscribe($bgColorSingleBgMode);
@@ -139,7 +139,7 @@ const BgSpanSingle = memo(function BgSingleSpan() {
 
   return (
     <GridCell
-      bgColor={singleBgColor}
+      bgColorType={singleBgColorType}
       bgMode={bgMode}
       className={clsx(styles.bgSpan, styles.single)}
     >
@@ -198,7 +198,7 @@ const BgSpanRight = memo(function BgLightSpan() {
   }, []);
 
   return (
-    <GridCell bgColor="right" bgMode={bgMode} className={clsx(styles.bgSpan, styles.right)}>
+    <GridCell bgColorType="right" bgMode={bgMode} className={clsx(styles.bgSpan, styles.right)}>
       <div className={styles.dragContainer}>
         <Button
           className={styles.dragButton}
@@ -230,7 +230,7 @@ const BgSpanRight = memo(function BgLightSpan() {
 export function EndSpacerCell() {
   const bgMode = useSubscribe($bgColorModeRight);
 
-  return <GridCell bgColor="right" bgMode={bgMode} className={styles.endSpacerCell} />;
+  return <GridCell bgColorType="right" bgMode={bgMode} className={styles.endSpacerCell} />;
 }
 
 export const GridRowBackground = memo(function GridRowBackground() {

--- a/packages/core/src/components/List/List.tsx
+++ b/packages/core/src/components/List/List.tsx
@@ -16,7 +16,7 @@ export function List<E extends ElementType>({ as, className, ...restProps }: Lis
   return (
     <BgMode
       as={Component}
-      bgColor={null}
+      bgColorType={null}
       bgMode="dark"
       className={clsx(styles.list, className)}
       {...restProps}

--- a/packages/core/src/schemas/brand.ts
+++ b/packages/core/src/schemas/brand.ts
@@ -36,6 +36,9 @@ export type LightnessLevel = Brand<typeof LightnessLevel>;
 export const ColorString = createBrand<string, "ColorString">;
 export type ColorString = Brand<typeof ColorString>;
 
+export const ColorVariable = createBrand<`var(--${string})`, "ColorCssVariable">;
+export type ColorVariable = Brand<typeof ColorVariable>;
+
 /* Settings brand types */
 export const CHROMA_MODES = ["even", "max"] as const;
 export const ChromaMode = createBrand<(typeof CHROMA_MODES)[number], "ChromaMode">;

--- a/packages/core/src/stores/hooks.ts
+++ b/packages/core/src/stores/hooks.ts
@@ -1,13 +1,13 @@
 import { useSubscribe } from "@spred/react";
 
-import type { BgColor, BgModeType } from "@core/components/BgMode/types";
+import type { BgColorType, BgModeType } from "@core/components/BgMode/types";
 import { $levelIdsToIndex } from "@core/stores/colors";
 import type { LevelId } from "@core/types";
 import { invariant } from "@core/utils/assertions/invariant";
 
 import { $bgColorModeLeft, $bgColorModeRight, $bgRightStart } from "./settings";
 
-export function useLevelBgColor(levelId: LevelId): BgColor {
+export function useLevelBgColorType(levelId: LevelId): BgColorType {
   const levelIdsToIndex = useSubscribe($levelIdsToIndex);
   const bgRightStart = useSubscribe($bgRightStart);
   const levelIndex = levelIdsToIndex[levelId];

--- a/packages/core/src/stores/hooks.ts
+++ b/packages/core/src/stores/hooks.ts
@@ -1,6 +1,7 @@
 import { useSubscribe } from "@spred/react";
 
 import type { BgColorType, BgModeType } from "@core/components/BgMode/types";
+import { ColorVariable } from "@core/schemas/brand";
 import { $levelIdsToIndex } from "@core/stores/colors";
 import type { LevelId } from "@core/types";
 import { invariant } from "@core/utils/assertions/invariant";
@@ -15,6 +16,12 @@ export function useLevelBgColorType(levelId: LevelId): BgColorType {
   invariant(levelIndex !== undefined, "Level not found for the given ID");
 
   return levelIndex < bgRightStart ? "left" : "right";
+}
+
+export function useLevelBgColorVariable(levelId: LevelId): ColorVariable {
+  const colorType = useLevelBgColorType(levelId);
+
+  return colorType === "left" ? ColorVariable("var(--bg-left)") : ColorVariable("var(--bg-right)");
 }
 
 export function useLevelBgMode(levelId: LevelId): BgModeType {

--- a/packages/core/src/stores/settings.ts
+++ b/packages/core/src/stores/settings.ts
@@ -90,7 +90,7 @@ export const $bgColorSingleBgMode = signal((get) =>
   getBgMode(get(get($bgColorSingleStore).$lastValidValue)),
 );
 
-export const $bgColorSingleBgColor = signal((get) => {
+export const $bgColorSingleBgColorType = signal((get) => {
   if (get($isSingleBgRight)) {
     return "right";
   }

--- a/packages/web-app/src/components/FigmaPluginBanner/FigmaPluginBanner.tsx
+++ b/packages/web-app/src/components/FigmaPluginBanner/FigmaPluginBanner.tsx
@@ -14,7 +14,7 @@ export const $isBannerClosed = persistedSignal("harmonizer:figma-plugin-banner-c
 
 export function FigmaPluginBanner() {
   return (
-    <BgMode bgColor={null} bgMode="dark" className={styles.container}>
+    <BgMode bgColorType={null} bgMode="dark" className={styles.container}>
       <div className={styles.innerContainer}>
         <Link
           className={styles.link}


### PR DESCRIPTION
- `BgColor` was renamed to `BgColorType` to make it clearer that it doesn't contain raw color, but just points to the color type ('left' or 'right').
- Fixes bug with the wrong input color in the `LevelHeader` component.

Closes #50

