### PR TITLE
Fix contrast model toggle not updating its own button state

### DIFF
--- a/packages/core/src/stores/settings.ts
+++ b/packages/core/src/stores/settings.ts
@@ -99,8 +99,9 @@ export const $bgColorSingleBgColorType = signal((get) => {
 });
 
 export function updateContrastModel(model: ContrastModel) {
+  contrastModelStore.$raw.set(model);
+
   batch(() => {
-    contrastModelStore.$raw.set(model);
     for (const level of levels.values()) {
       level.contrast.$raw.set(
         LevelContrast(


### PR DESCRIPTION
## Overview
Fixed a UI bug where the contrast model toggle button did not update its displayed value immediately when clicked, even though the underlying model was being updated correctly.

## Problem Statement
When users clicked the contrast model toggle button (switching between "apca" and "wcag"), the button text did not update to reflect the new value. The button remained showing the old contrast model value until other UI updates occurred, creating a confusing user experience where the button appeared unresponsive despite the action being processed.

The root cause was in the reactive state management flow. The button subscribed to `contrastModelStore.$lastValidValue` to display the current model. Inside the `updateContrastModel` function, the store update (`contrastModelStore.$raw.set(model)`) was wrapped within a `batch()` call alongside the conversion of all level contrast values. When updates are batched, the signals framework defers subscriber notifications until the batch completes. This meant the button wouldn't see the store update until all level contrasts had been converted, causing a noticeable delay in the button's visual feedback.

## Solution Approach
- **Moved store update outside batch**: Relocated `contrastModelStore.$raw.set(model)` to execute immediately before the `batch()` block in the `updateContrastModel` function.
  - This allows the contrast model store to update and notify subscribers (including the toggle button) immediately
  - The button now reflects the new value as soon as the user clicks it
  - The subsequent batched operations (converting level contrasts from APCA to WCAG or vice versa) still benefit from batched processing but no longer block the button's UI update

## Breaking Changes
None. This is a bug fix that improves UI responsiveness without changing any public APIs or behavior beyond fixing the visual state update timing.

fixes #55 