### PR TITLE
fix: block export while any value is invalid

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "@zag-js/menu": "^1.38.2",
     "@zag-js/react": "^1.38.2",
-    "@zag-js/select": "^1.38.2"
+    "@zag-js/select": "^1.38.2",
+    "@zag-js/tooltip": "^1.38.2"
   },
   "devDependencies": {
     "cross-env": "^10.1.0",

--- a/packages/core/src/components/Button/Button.module.css
+++ b/packages/core/src/components/Button/Button.module.css
@@ -24,7 +24,8 @@
     outline: 2px solid var(--color-universal-focus);
   }
 
-  &[disabled] {
+  &:is([disabled], [aria-disabled="true"]),
+  &:is([disabled], [aria-disabled="true"]):hover {
     cursor: not-allowed;
     color: var(--color-secondary);
     background-color: var(--color-button-disabled);

--- a/packages/core/src/components/ExportImportMenu/ExportImportMenu.tsx
+++ b/packages/core/src/components/ExportImportMenu/ExportImportMenu.tsx
@@ -11,6 +11,7 @@ export type ExportImportMenuProps = {
 export function ExportImportMenu({ children }: ExportImportMenuProps) {
   return (
     <Menu
+      placement="top"
       renderTrigger={(triggerProps, indicatorProps) => (
         <Button
           size="m"

--- a/packages/core/src/components/ExportImportMenu/items/ExportConfigsList.tsx
+++ b/packages/core/src/components/ExportImportMenu/items/ExportConfigsList.tsx
@@ -1,5 +1,8 @@
+import { useSubscribe } from "@spred/react";
+
 import { MenuItemButton } from "@core/components/Menu/MenuItemButton";
-import { downloadConfigTarget, ExportTargets } from "@core/stores/config";
+import { Tooltip } from "@core/components/Tooltip/Tooltip";
+import { $isExportConfigValid, downloadConfigTarget, ExportTargets } from "@core/stores/config";
 import { objectEntries } from "@core/utils/object/objectEntries";
 
 export type ExportConfigsListProps = {
@@ -7,16 +10,27 @@ export type ExportConfigsListProps = {
 };
 
 export function ExportConfigsList({ onClick }: ExportConfigsListProps) {
+  const isValid = useSubscribe($isExportConfigValid);
+
   return objectEntries(ExportTargets).map(([exportTarget, config]) => (
-    <MenuItemButton
+    <Tooltip
       key={exportTarget}
-      value={exportTarget}
-      onClick={() => {
-        downloadConfigTarget(exportTarget);
-        onClick?.(exportTarget);
-      }}
-    >
-      {config.name}
-    </MenuItemButton>
+      content="Fix invalid values to export"
+      disabled={isValid}
+      placement="left"
+      renderTrigger={(triggerProps) => (
+        <MenuItemButton
+          {...triggerProps}
+          value={exportTarget}
+          disabled={!isValid}
+          onClick={() => {
+            downloadConfigTarget(exportTarget);
+            onClick?.(exportTarget);
+          }}
+        >
+          {config.name}
+        </MenuItemButton>
+      )}
+    />
   ));
 }

--- a/packages/core/src/components/ExportImportMenu/items/OpenInWebApp.tsx
+++ b/packages/core/src/components/ExportImportMenu/items/OpenInWebApp.tsx
@@ -1,15 +1,30 @@
 import { useSubscribe } from "@spred/react";
 
 import { MenuItemLink } from "@core/components/Menu/MenuItemLink";
-import { $exportConfigHash } from "@core/stores/config";
+import { Tooltip } from "@core/components/Tooltip/Tooltip";
+import { $exportConfigHash, $isExportConfigValid } from "@core/stores/config";
 import { getShareUrl } from "@core/utils/url/getShareUrl";
 
 export function OpenInWebApp() {
   const configHash = useSubscribe($exportConfigHash);
+  const isValid = useSubscribe($isExportConfigValid);
 
   return (
-    <MenuItemLink value="open-in-web" href={getShareUrl(configHash)} target="_blank">
-      Open in web app
-    </MenuItemLink>
+    <Tooltip
+      content="Fix invalid values to open the palette in the web app"
+      disabled={isValid}
+      placement="left"
+      renderTrigger={(triggerProps) => (
+        <MenuItemLink
+          {...triggerProps}
+          value="open-in-web"
+          href={getShareUrl(configHash)}
+          target="_blank"
+          disabled={!isValid}
+        >
+          Open in web app
+        </MenuItemLink>
+      )}
+    />
   );
 }

--- a/packages/core/src/components/Icon/MLink.tsx
+++ b/packages/core/src/components/Icon/MLink.tsx
@@ -7,6 +7,7 @@ export function MLink(props: MLinkProps) {
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" {...props}>
       <path
         stroke="currentColor"
+        fill="none"
         d="m10.5 5.5-5 5m2-2a2.121 2.121 0 0 1 0 3l-1 1a2.121 2.121 0 1 1-3-3l1-1a2.121 2.121 0 0 1 3 0Zm4-1 1-1a2.121 2.121 0 1 0-3-3l-1 1a2.121 2.121 0 1 0 3 3Z"
       />
     </svg>

--- a/packages/core/src/components/List/List.module.css
+++ b/packages/core/src/components/List/List.module.css
@@ -22,6 +22,10 @@
   padding: 0 calc(var(--spacing) * 2);
 
   outline: none;
+
+  &[data-disabled] {
+    cursor: not-allowed;
+  }
 }
 
 .groupLabel {
@@ -41,6 +45,10 @@
   :where(.item[data-highlighted]) &,
   :where(.item:hover) & {
     background-color: var(--color-universal-elevation-hover);
+  }
+
+  :where(.item[data-disabled]) & {
+    background-color: transparent;
   }
 }
 

--- a/packages/core/src/components/List/List.module.css
+++ b/packages/core/src/components/List/List.module.css
@@ -48,6 +48,8 @@
   }
 
   :where(.item[data-disabled]) & {
+    /* Dimmed primary, so a blocked item never reads as a group label */
+    opacity: 0.35;
     background-color: transparent;
   }
 }

--- a/packages/core/src/components/Menu/Menu.tsx
+++ b/packages/core/src/components/Menu/Menu.tsx
@@ -13,14 +13,15 @@ export type MenuProps = {
     triggerProps: HTMLAttributes<HTMLButtonElement>,
     indicatorProps: Record<`data-${string}`, string>,
   ) => ReactNode;
+  placement?: menu.PositioningOptions["placement"];
   children: ReactElement | ReactElement[];
 };
 
-export function Menu({ renderTrigger, children }: MenuProps) {
+export function Menu({ renderTrigger, children, placement }: MenuProps) {
   const service = useMachine(menu.machine, {
     id: useId(),
     loopFocus: true,
-    positioning: { offset: { mainAxis: 2, crossAxis: 0 } },
+    positioning: { offset: { mainAxis: 2, crossAxis: 0 }, placement },
   });
   const api = menu.connect(service, normalizeProps);
 

--- a/packages/core/src/components/Menu/MenuItemButton.tsx
+++ b/packages/core/src/components/Menu/MenuItemButton.tsx
@@ -8,11 +8,25 @@ export type MenuItemProps = Omit<ListItemProps<"button">, "as"> & {
   value: string;
 };
 
-export function MenuItemButton({ value, children, ...restProps }: MenuItemProps) {
+// A disabled item keeps its DOM events so a tooltip can still explain why it is blocked.
+// Keyboard navigation skips it anyway: the menu only walks items without [data-disabled].
+// Own props come first in the merge so the menu keeps control of the item id.
+export function MenuItemButton({
+  value,
+  disabled,
+  onClick,
+  children,
+  ...restProps
+}: MenuItemProps) {
   const api = useMenuApi();
 
   return (
-    <ListItem as="button" {...mergeProps(api.getItemProps({ value }), restProps)}>
+    <ListItem
+      as="button"
+      {...mergeProps(restProps, api.getItemProps({ value, disabled }), {
+        onClick: disabled ? undefined : onClick,
+      })}
+    >
       <ListItemContent>{children}</ListItemContent>
     </ListItem>
   );

--- a/packages/core/src/components/Menu/MenuItemLink.tsx
+++ b/packages/core/src/components/Menu/MenuItemLink.tsx
@@ -6,13 +6,18 @@ import { useMenuApi } from "./MenuContext";
 
 export type MenuItemProps = Omit<ListItemProps<"a">, "as"> & {
   value: string;
+  disabled?: boolean;
 };
 
-export function MenuItemLink({ value, children, ...restProps }: MenuItemProps) {
+export function MenuItemLink({ value, disabled, href, children, ...restProps }: MenuItemProps) {
   const api = useMenuApi();
 
   return (
-    <ListItem as="a" {...mergeProps(api.getItemProps({ value }), restProps)}>
+    <ListItem
+      as="a"
+      href={disabled ? undefined : href}
+      {...mergeProps(restProps, api.getItemProps({ value, disabled }))}
+    >
       <ListItemContent>{children}</ListItemContent>
     </ListItem>
   );

--- a/packages/core/src/components/Tooltip/Tooltip.module.css
+++ b/packages/core/src/components/Tooltip/Tooltip.module.css
@@ -1,0 +1,11 @@
+.content {
+  max-inline-size: calc(var(--spacing) * 50);
+  padding: var(--spacing) calc(var(--spacing) * 1.5);
+  border: 1px solid var(--color-border-dark);
+  border-radius: var(--radius-sm);
+
+  color: var(--color-primary-dark);
+
+  /* Sits above the menu, which uses the plain elevation color */
+  background-color: var(--color-universal-elevation-hover);
+}

--- a/packages/core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/core/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,55 @@
+import { type HTMLAttributes, type ReactNode, type RefCallback, useId, useRef } from "react";
+
+import { normalizeProps, Portal, useMachine } from "@zag-js/react";
+import * as tooltip from "@zag-js/tooltip";
+
+import { Text } from "@core/components/Text/Text";
+
+import styles from "./Tooltip.module.css";
+
+export type TooltipTriggerProps = HTMLAttributes<HTMLElement> & { ref: RefCallback<HTMLElement> };
+
+export type TooltipProps = {
+  content: ReactNode;
+  disabled?: boolean;
+  placement?: tooltip.Placement;
+  renderTrigger: (triggerProps: TooltipTriggerProps) => ReactNode;
+};
+
+const OPEN_DELAY_MS = 200;
+
+export function Tooltip({ content, disabled, placement = "top", renderTrigger }: TooltipProps) {
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const setTriggerRef: RefCallback<HTMLElement> = (element) => {
+    triggerRef.current = element;
+  };
+  const service = useMachine(tooltip.machine, {
+    id: useId(),
+    disabled,
+    openDelay: OPEN_DELAY_MS,
+    closeDelay: 0,
+    positioning: {
+      placement,
+      offset: { mainAxis: 4, crossAxis: 0 },
+      // A trigger can carry props from another zag machine (a menu item does), which takes over
+      // the id and data attributes the tooltip would look itself up by. The ref always works.
+      getAnchorRect: () => triggerRef.current?.getBoundingClientRect() ?? null,
+    },
+  });
+  const api = tooltip.connect(service, normalizeProps);
+
+  return (
+    <>
+      {renderTrigger({ ...api.getTriggerProps(), ref: setTriggerRef })}
+      {api.open && (
+        <Portal>
+          <div {...api.getPositionerProps()}>
+            <Text as="div" size="s" {...api.getContentProps()} className={styles.content}>
+              {content}
+            </Text>
+          </div>
+        </Portal>
+      )}
+    </>
+  );
+}

--- a/packages/core/src/stores/colors.ts
+++ b/packages/core/src/stores/colors.ts
@@ -77,7 +77,8 @@ export const $areLevelsValid = signal((get) => {
     return (
       !get(level.name.$validationError) &&
       !get(level.contrast.$validationError) &&
-      !get(level.chroma.$validationError)
+      !get(level.chroma.$validationError) &&
+      !get(level.chromaCap.$validationError)
     );
   });
 

--- a/packages/core/src/stores/config.test.ts
+++ b/packages/core/src/stores/config.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { ColorString, HueName, LevelChroma, LevelContrast, LevelName } from "@core/types";
+import { downloadTextFile } from "@core/utils/file/downloadTextFile";
+
+import { $exportConfigHash, $isExportConfigValid, downloadConfigTarget } from "./config";
+import { bgColorLeftStore } from "./settings";
+import {
+  cleanupFakeTimersAndRAF,
+  resetStores,
+  setupFakeTimersAndRAF,
+  setupTestGrid,
+  type TestHueOverrides,
+  type TestLevelOverrides,
+} from "./test-utils";
+
+vi.mock("@core/utils/file/downloadTextFile", () => ({ downloadTextFile: vi.fn() }));
+
+const HASH_DEBOUNCE_MS = 300;
+
+function setupGrid(
+  levels: TestLevelOverrides[] = [{ name: "100" }, { name: "500" }],
+  hues: TestHueOverrides[] = [{ name: "Blue" }],
+) {
+  return setupTestGrid(levels, hues);
+}
+
+describe("export config validity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
+  });
+
+  test("is valid for a complete grid", () => {
+    setupGrid();
+
+    expect($isExportConfigValid.value).toBe(true);
+  });
+
+  test("is invalid when a level has no name", () => {
+    const { levelStores } = setupGrid();
+
+    levelStores[0]?.name.$raw.set(LevelName(""));
+
+    expect($isExportConfigValid.value).toBe(false);
+  });
+
+  test("is invalid when a hue has no name", () => {
+    const { hueStores } = setupGrid();
+
+    hueStores[0]?.name.$raw.set(HueName(""));
+
+    expect($isExportConfigValid.value).toBe(false);
+  });
+
+  test("is invalid when a level contrast is out of range", () => {
+    const { levelStores } = setupGrid();
+
+    levelStores[0]?.contrast.$raw.set(LevelContrast(1000));
+
+    expect($isExportConfigValid.value).toBe(false);
+  });
+
+  test("is invalid when a level chroma cap is out of range", () => {
+    const { levelStores } = setupGrid();
+
+    levelStores[0]?.chromaCap.$raw.set(LevelChroma(10));
+
+    expect($isExportConfigValid.value).toBe(false);
+  });
+
+  test("is invalid when a background color is not a color", () => {
+    setupGrid();
+
+    bgColorLeftStore.$raw.set(ColorString("definitely not a color"));
+
+    expect($isExportConfigValid.value).toBe(false);
+  });
+});
+
+describe("export blocking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStores();
+  });
+
+  test("downloads the file when everything is valid", () => {
+    setupGrid();
+
+    downloadConfigTarget("harmonizer");
+
+    expect(downloadTextFile).toHaveBeenCalledOnce();
+  });
+
+  test("downloads nothing when a level has no name", () => {
+    const { levelStores } = setupGrid();
+
+    levelStores[0]?.name.$raw.set(LevelName(""));
+    downloadConfigTarget("harmonizer");
+
+    expect(downloadTextFile).not.toHaveBeenCalled();
+  });
+
+  test("keeps the url hash untouched while a value is invalid", async () => {
+    setupFakeTimersAndRAF();
+    const { levelStores } = setupGrid();
+    const hashBeforeChange = $exportConfigHash.value;
+
+    levelStores[0]?.name.$raw.set(LevelName(""));
+    await vi.advanceTimersByTimeAsync(HASH_DEBOUNCE_MS);
+
+    expect($exportConfigHash.value).toBe(hashBeforeChange);
+  });
+
+  afterEach(() => {
+    cleanupFakeTimersAndRAF();
+  });
+});

--- a/packages/core/src/stores/config.ts
+++ b/packages/core/src/stores/config.ts
@@ -29,6 +29,7 @@ import {
   requestColorsRecalculation,
 } from "./colors";
 import {
+  $areSettingsValid,
   $bgRightStart,
   $isColorSpaceLocked,
   bgColorLeftStore,
@@ -70,13 +71,26 @@ export const $exportConfig = signal<ExportConfig>((get) => {
   };
 });
 
+export const $isExportConfigValid = signal(
+  (get) => get($areLevelsValid) && get($areHuesValid) && get($areSettingsValid),
+);
+
 export const $exportConfigHash = signal<string>("#");
+
+const $exportConfigSnapshot = signal((get) => ({
+  config: get($exportConfig),
+  isValid: get($isExportConfigValid),
+}));
 
 const COMPRESSION_DEBOUNCE_MS = 300;
 let exportConfigHashAbortController: AbortController | null = null;
 
-$exportConfig.subscribe(
-  debounce(async (config) => {
+$exportConfigSnapshot.subscribe(
+  debounce(async ({ config, isValid }) => {
+    if (!isValid) {
+      return;
+    }
+
     if (exportConfigHashAbortController) {
       exportConfigHashAbortController.abort();
     }
@@ -100,8 +114,6 @@ $exportConfig.subscribe(
     }
   }, COMPRESSION_DEBOUNCE_MS),
 );
-
-export const $isExportConfigValid = signal((get) => get($areLevelsValid) && get($areHuesValid));
 
 export function getConfig(): ExportConfig {
   return $exportConfig.value;
@@ -221,6 +233,10 @@ export const ExportTargets = {
 export type ExportTarget = keyof typeof ExportTargets;
 
 export function downloadConfigTarget(type: ExportTarget) {
+  if (!$isExportConfigValid.value) {
+    return;
+  }
+
   const targetConfig = ExportTargets[type];
 
   downloadTextFile({

--- a/packages/core/src/stores/settings.ts
+++ b/packages/core/src/stores/settings.ts
@@ -59,6 +59,17 @@ export const bgColorRightStore = validationStore(
   colorStringSchema,
 );
 
+export const $areSettingsValid = signal((get) =>
+  [
+    contrastModelStore,
+    directionModeStore,
+    chromaModeStore,
+    colorSpaceStore,
+    bgColorLeftStore,
+    bgColorRightStore,
+  ].every((store) => !get(store.$validationError)),
+);
+
 export const $bgRightStart = signal(BgRightStart(defaultConfig.settings.bgLightStart));
 export const $isSingleBgLeft = signal((get) =>
   isSingleBgLeft(get($bgRightStart), get($levelsCount)),

--- a/packages/figma-plugin/src/ui/components/FigmaPluginActions/FigmaPluginActions.tsx
+++ b/packages/figma-plugin/src/ui/components/FigmaPluginActions/FigmaPluginActions.tsx
@@ -11,7 +11,9 @@ import { UploadConfig } from "@core/components/ExportImportMenu/items/UploadConf
 import { MFourSquares } from "@core/components/Icon/MFourSquares";
 import { MenuItemGroup } from "@core/components/Menu/MenuItemGroup";
 import { MenuItemSeparator } from "@core/components/Menu/MenuItemSeparator";
+import { Tooltip } from "@core/components/Tooltip/Tooltip";
 import { $isExportConfigValid, getExportConfigWithColors } from "@core/stores/config";
+import { mergeProps } from "@core/utils/react/mergeProps";
 
 function upsertPalette() {
   pluginChannel.emit("palette:generate", getExportConfigWithColors());
@@ -24,15 +26,21 @@ export function FigmaPluginActions({ hasPalette }: FigmaPluginActionsProps) {
 
   return (
     <>
-      <Button
-        kind="floating"
-        size="m"
-        onClick={upsertPalette}
-        iconStart={<MFourSquares />}
-        disabled={!isValid}
-      >
-        {hasPalette ? "Update palette" : "Create palette"}
-      </Button>
+      <Tooltip
+        content={`Fix invalid values to ${hasPalette ? "update" : "create"} the palette`}
+        disabled={isValid}
+        renderTrigger={(triggerProps) => (
+          <Button
+            {...mergeProps(triggerProps, { onClick: isValid ? upsertPalette : undefined })}
+            kind="floating"
+            size="m"
+            iconStart={<MFourSquares />}
+            aria-disabled={!isValid}
+          >
+            {hasPalette ? "Update palette" : "Create palette"}
+          </Button>
+        )}
+      />
       <ExportImportMenu>
         <MenuItemGroup id="menu-group-upload" label="Import">
           <PasteWebAppUrl value="paste-url" />

--- a/packages/web-app/src/components/WebAppActions/WebAppActions.tsx
+++ b/packages/web-app/src/components/WebAppActions/WebAppActions.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 
+import { useSubscribe } from "@spred/react";
 import { trackEvent } from "@web-app/plausible";
 
 import { Button } from "@core/components/Button/Button";
@@ -12,9 +13,13 @@ import { MCheck } from "@core/components/Icon/MCheck";
 import { MLink } from "@core/components/Icon/MLink";
 import { MenuItemGroup } from "@core/components/Menu/MenuItemGroup";
 import { MenuItemSeparator } from "@core/components/Menu/MenuItemSeparator";
+import { Tooltip } from "@core/components/Tooltip/Tooltip";
+import { $isExportConfigValid } from "@core/stores/config";
+import { mergeProps } from "@core/utils/react/mergeProps";
 
 const TIMEOUT = 2000;
 export function CopyPermantentUrlButton() {
+  const isValid = useSubscribe($isExportConfigValid);
   const [isCopied, setIsCopied] = useState(false);
 
   const handleCopy = useCallback(async () => {
@@ -25,12 +30,19 @@ export function CopyPermantentUrlButton() {
   }, []);
 
   return (
-    <Button
-      kind="floating"
-      size="m"
-      icon={isCopied ? <MCheck /> : <MLink />}
-      aria-label="Copy URL"
-      onClick={handleCopy}
+    <Tooltip
+      content="Fix invalid values to copy the link"
+      disabled={isValid}
+      renderTrigger={(triggerProps) => (
+        <Button
+          {...mergeProps(triggerProps, { onClick: isValid ? handleCopy : undefined })}
+          kind="floating"
+          size="m"
+          icon={isCopied ? <MCheck /> : <MLink />}
+          aria-label="Copy URL"
+          aria-disabled={!isValid}
+        />
+      )}
     />
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ importers:
       '@zag-js/select':
         specifier: ^1.38.2
         version: 1.38.2
+      '@zag-js/tooltip':
+        specifier: ^1.38.2
+        version: 1.38.2
     devDependencies:
       cross-env:
         specifier: ^10.1.0
@@ -1121,6 +1124,9 @@ packages:
 
   '@zag-js/store@1.38.2':
     resolution: {integrity: sha512-TlJM6M2dW5W9jr6US4/R/VobLmlFrSv48ls18XffmXp+uuwZ7Aisciq0Djtwx7Y7e5KhlUWtk4ncE5PtjP4AzQ==}
+
+  '@zag-js/tooltip@1.38.2':
+    resolution: {integrity: sha512-pFVWc6KjLujIvyOz2CzFQu4e9NVC61yE0oQpjRIQwzZAICxxiPE3QeOtb0Aw3Jhd0n2Y7qxuLyFI6gcAxI9Sxg==}
 
   '@zag-js/types@1.38.2':
     resolution: {integrity: sha512-fvUf3J4QOFAliuo5wHTO/awO0GKFAn5AHNOXbGH5IuoxIwa0oK5tSXVwdF8JE7ISOkQh4oB2fq3g4QjxmAXDyA==}
@@ -2871,6 +2877,16 @@ snapshots:
   '@zag-js/store@1.38.2':
     dependencies:
       proxy-compare: 3.0.1
+
+  '@zag-js/tooltip@1.38.2':
+    dependencies:
+      '@zag-js/anatomy': 1.38.2
+      '@zag-js/core': 1.38.2
+      '@zag-js/dom-query': 1.38.2
+      '@zag-js/focus-visible': 1.38.2
+      '@zag-js/popper': 1.38.2
+      '@zag-js/types': 1.38.2
+      '@zag-js/utils': 1.38.2
 
   '@zag-js/types@1.38.2':
     dependencies:


### PR DESCRIPTION
## Overview
Blocks every export path while the palette holds an invalid value, and explains the block with a tooltip.
Adds a `Tooltip` component built on `@zag-js/tooltip` (new dependency).

## Problem Statement
Reported in #67. Inserting a column between two columns whose names are not numbers leaves the new column with an empty name. The app still exported that state, writing `"name": false` into the file. Importing it back failed with "Couldn't parse file. It should be Harmonizer config", which says nothing about the real cause.

The URL hash had the same problem and it was worse: the address bar was updated with the broken config, so a reload could not parse it and dropped the user back to the default palette, losing their work.

The check that was supposed to catch this was also incomplete. It did not cover the chroma cap that users actually edit, nor the settings (background colors, contrast model, color space), so invalid values there never blocked anything.

## Solution Approach
- `$isExportConfigValid` now covers everything that goes into the exported config: level names, contrast, chroma and chroma cap, hue names and angles, and all settings stores.
- File downloads, the permanent URL button, "Open in web app" and the Figma "Create/Update palette" button are all blocked while the config is invalid. The Figma button was already blocked, but with nothing telling users why.
- The URL hash stops updating while the config is invalid, so the address bar keeps the last valid palette and a reload no longer loses work.
- A new `Tooltip` component says what to fix on every blocked control. Blocked controls use `aria-disabled` instead of the native `disabled` attribute, because a natively disabled element fires no pointer or focus events and could never show a tooltip. They stay focusable, the tooltip opens on hover and on keyboard focus, and the reason is announced through `aria-describedby`.
- Menu items gained a `disabled` prop, and buttons and list items gained a disabled look for the `aria-disabled` state.

## Breaking Changes
None.

## Testing
Reproduce the original report: rename a column to something that is not a number, then insert a new column next to it. The new column has no name.

While in that state:
- The four items in the Export menu are dimmed, and hovering one shows "Fix invalid values to export". Clicking downloads nothing.
- The Copy URL button is dimmed and copies nothing.
- The address bar keeps the previous palette. Reloading restores it instead of falling back to the default palette.
- In the Figma plugin, the Create/Update palette button and "Open in web app" behave the same way.

Naming the new column re-enables every control, and the URL catches up with the new palette.

Closes #67